### PR TITLE
extra_fields functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,26 @@ Example:
     handler = GelfUdpHandler(host='127.0.0.1', port=9402, _app_name='pygelf', _something=11)
     logger.addHandler(handler)
 
+Extra fields
+============
+
+If you need to include some dynamic fields into your logs, add them to record by using LoggingAdapter or logging.Filter and create handler with extra_fields set to True.
+All the non-trivial fields of the record will be sent to graylog2 with '\_' added before the name
+
+ Example:
+
+ .. code-block:: python
+
+    class ContextFilter(logging.Filter):
+
+        def filter(self, record):
+            record.job_id = threading.local().process_id # for example logging job_id of currently processed job
+            return True
+
+    logger.addFilter(ContextFilter())
+    handler = GelfUdpHandler(host='127.0.0.1', port=9402, extra_fields=True)
+    logger.addHandler(handler)
+
 Running tests
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -78,12 +78,12 @@ All the non-trivial fields of the record will be sent to graylog2 with '\_' adde
 
  Example:
 
- .. code-block:: python
+ .. code:: python
 
     class ContextFilter(logging.Filter):
 
         def filter(self, record):
-            record.job_id = threading.local().process_id # for example logging job_id of currently processed job
+            record.job_id = threading.local().process_id # logging job_id of currently processed job
             return True
 
     logger.addFilter(ContextFilter())

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Each handler has the following parameters:
 - **port**: port of the GELF input
 - **debug** (false by default): if true, each log message will include debugging info: module name, file name, line number, method name
 - **version** ('1.1' by default): GELF protocol version, can be overridden by a client
+- **extra_fields** (False by default): if true, each log message will include all the extra fields set to LogRecord
 
 In addition UDP and TLS handlers have some specific parameters.
 

--- a/tests/test_extra_fields.py
+++ b/tests/test_extra_fields.py
@@ -1,0 +1,62 @@
+from pygelf import GelfTcpHandler, GelfUdpHandler, GelfTlsHandler
+import logging
+import json
+import pytest
+import mock
+
+
+@pytest.yield_fixture
+def send(extra_fields_handler):
+    with mock.patch.object(extra_fields_handler, 'send') as mock_send:
+        yield mock_send
+
+
+@pytest.fixture(params=[
+    GelfTcpHandler(host='127.0.0.1', port=12000, extra_fields=True),
+    GelfUdpHandler(host='127.0.0.1', port=12000, compress=False, extra_fields=True),
+    GelfTlsHandler(host='127.0.0.1', port=12000, extra_fields=True)
+])
+def extra_fields_handler(request):
+    return request.param
+
+
+ADDITIONAL_FIELDS = {
+    '_ozzy': 'diary of a madman',
+    '_van_halen': 1984,
+    '_id': '123'
+}
+
+
+class ContextFilter(logging.Filter):
+    def filter(self, record):
+        record.ozzy = 'diary of a madman'
+        record.van_halen = 1984
+        record.id = 123
+
+        return True
+
+
+@pytest.yield_fixture
+def extra_fields_logger(extra_fields_handler):
+    extra_fields_logger = logging.getLogger('test')
+    context_filter = ContextFilter()
+    extra_fields_logger.addFilter(context_filter)
+    extra_fields_logger.addHandler(extra_fields_handler)
+    yield extra_fields_logger
+    extra_fields_logger.removeHandler(extra_fields_handler)
+    extra_fields_logger.removeFilter(context_filter)
+
+
+def log_and_decode(_logger, _send, text, *args):
+    _logger.exception(text) if isinstance(text, Exception) else _logger.warning(text, *args)
+    message = _send.call_args[0][0].replace(b'\x00', b'').decode('utf-8')
+    return json.loads(message)
+
+
+def test_extra_fields(extra_fields_logger, send):
+    message = log_and_decode(extra_fields_logger, send, 'hello gelf')
+    assert '_id' not in message # same fields was set thru filter
+    for k, v in ADDITIONAL_FIELDS.items():
+        if k != '_id':
+            assert message[k] == v
+


### PR DESCRIPTION
Extra fields functionality allows to add dynamic context information to messages sent to graylog.
Code is actually copy pasted from graypy as your library lacks this functionality, and their library lacks TCP, and I need both.

Could you please review this change and let me know if you can accept it?

Thanks, Ivan