### PR TITLE
Send client certificates for server-side TLS client authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,8 @@ TLS:
 
 - **validate** (False by default) - if true, validate server certificate. If server provides a certificate that doesn't exist in **ca_certs**, you won't be able to send logs over TLS
 - **ca_certs** (None by default) - path to CA bundle file. This parameter is required if **validate** is true.
+- **certfile** (None by default) - path to certificate file that will be used to identify ourselves to the remote endpoint. This is necessary when the remote server has client authentication required. If **certfile** contains the private key, it should be placed before the certificate.
+- **keyfile** (None by default) - path to the private key. If the private key is stored in **certfile** this parameter can be None.
 
 Static fields
 =============

--- a/tests/test_tls_handler.py
+++ b/tests/test_tls_handler.py
@@ -32,3 +32,7 @@ def test_ending_null_character(logger, send):
 def test_handler_creation():
     with pytest.raises(ValueError):
         GelfTlsHandler(host='127.0.0.1', port=12001, validate=True)
+
+def test_handler_certfile_required_for_keyfile():
+    with pytest.raises(ValueError):
+        GelfTlsHandler(host='127.0.0.1', port=12001, keyfile="./somefile.key")


### PR DESCRIPTION
This allows to authenticate clients using pygelf against servers using TLS client authentication required.

Build passing: https://travis-ci.org/jsargiot/pygelf/builds/182416962

Tested against GELF TCP TLS input on graylog 2.1.2