### PR TITLE
Add PyPi trove classifiers to document Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,23 @@ setup(
     author_email='muhin.ivan@gmail.com',
     url='https://github.com/keeprocking/pygelf',
     long_description=open('README.rst').read(),
-    license='MIT'
+    license='MIT',
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: System :: Logging',
+        'Topic :: Software Development :: Libraries :: Python Modules'
+    ],
 )


### PR DESCRIPTION
Add PyPi trove classifiers (https://pypi.python.org/pypi?%3Aaction=list_classifiers) to document Python 3 support. Among other things this will prevent caniusepython3 from flagging pygelf as needing to be ported. 
Add other applicable classifiers while we're here.

I have not tested pygelf against Python 3 yet myself; I'm in the middle of porting something that uses pygelf. I wrote this change based on pygelf's Travis build.