### PR TITLE
Add support for using with a QueueHandler/QueueListener

### DIFF
--- a/pygelf/gelf.py
+++ b/pygelf/gelf.py
@@ -39,6 +39,9 @@ def make(record, domain, debug, version, additional_fields, include_extra_fields
 
     if record.exc_info is not None:
         gelf['full_message'] = '\n'.join(traceback.format_exception(*record.exc_info))
+    elif record.exc_text is not None:
+        # If a QueueHandler has already formatted the exc_info for us
+        gelf['full_message'] = record.exc_text
 
     if debug:
         gelf['_file'] = record.filename

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,15 +4,33 @@ import logging
 import json
 
 
+class FakeQueueHandler(logging.Handler):
+    def __init__(self, handler):
+        self.handler = handler
+        logging.Handler.__init__(self)
+
+    def emit(self, record):
+        # This is what python3's QueueHandler does to a logging record
+        # before it puts it on a Queue for a QueueListener to pick up
+        self.format(record)
+        record.msg = record.message
+        record.args = None
+        record.exc_info = None
+        self.handler.handle(record)
+
+
 @pytest.yield_fixture
 def send(handler):
     with mock.patch.object(handler, 'send') as mock_send:
         yield mock_send
 
 
-@pytest.yield_fixture
-def logger(handler):
+@pytest.yield_fixture(params=[True, False])
+def logger(request, handler):
     logger = logging.getLogger('test')
+    if request.param:
+        # Should be queued
+        handler = FakeQueueHandler(handler)
     logger.addHandler(handler)
     yield logger
     logger.removeHandler(handler)


### PR DESCRIPTION
If Python3's QueueHandler/QueueListener are used then record.exc_info is
None, but record.exc_text contains the traceback. Reading the source of
the logging module it would appear that exc_text can safely be assumed
to contain the exception text if it is not None, so use this to populate
graylog's full_message