### PR TITLE
Handle non-JSON serializable objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,7 @@ Each handler has the following parameters:
 - **debug** (False by default): if true, each log message will include debugging info: module name, file name, line number, method name
 - **version** ('1.1' by default): GELF protocol version, can be overridden
 - **include_extra_fields** (False by default): if true, each log message will include all the extra fields set to LogRecord
+- **json_default** (:code:`str` with exception for several :code:`datetime` objects): function that is called for objects that cannot be serialized to JSON natively by python. Default implementation is custom function that returns result of :code:`isoformat()` method for :code:`datetime.datetime`, :code:`datetime.time`, :code:`datetime.date` objects and result of :code:`str(obj)` call for other objects (which is string representation of an object with fallback to :code:`repr`)
 
 Also, there are some handler-specific parameters.
 

--- a/pygelf/gelf.py
+++ b/pygelf/gelf.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import json
 import zlib
@@ -66,8 +67,15 @@ def add_extra_fields(gelf, record):
             gelf['_%s' % key] = value
 
 
-def pack(gelf, compress):
-    packed = json.dumps(gelf).encode('utf-8')
+def object_to_json(obj):
+    """Convert object that cannot be natively serialized by python to JSON representation."""
+    if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
+        return obj.isoformat()
+    return str(obj)
+
+
+def pack(gelf, compress, default):
+    packed = json.dumps(gelf, separators=(',', ':'), default=default).encode('utf-8')
     return zlib.compress(packed) if compress else packed
 
 

--- a/pygelf/handlers.py
+++ b/pygelf/handlers.py
@@ -13,12 +13,13 @@ from pygelf import gelf
 
 class BaseHandler(object):
     def __init__(self, debug=False, version='1.1', include_extra_fields=False, compress=False,
-                 static_fields=None, **kwargs):
+                 static_fields=None, json_default=gelf.object_to_json, **kwargs):
         """
         Logging handler that transforms each record into GELF (graylog extended log format) and sends it over TCP.
 
         :param debug: include debug fields, e.g. line number, or not
         :param include_extra_fields: include non-default fields from record to message, or not
+        :param json_default: function that is called for objects that cannot be serialized to JSON natively by python
         :param kwargs: additional fields that will be included in the log message, e.g. application name.
                        Each additional field should start with underscore, e.g. _app_name
         """
@@ -30,11 +31,12 @@ class BaseHandler(object):
         self.additional_fields.pop('_id', None)
         self.domain = socket.getfqdn()
         self.compress = compress
+        self.json_default = json_default
 
     def convert_record_to_gelf(self, record):
         return gelf.pack(
             gelf.make(record, self.domain, self.debug, self.version, self.additional_fields, self.include_extra_fields),
-            self.compress
+            self.compress, self.json_default
         )
 
 

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -1,17 +1,49 @@
+import datetime
 import json
-import zlib
 import struct
+import zlib
+
 import pytest
+
 from pygelf import gelf
+
+
+class _ObjWithStr:
+    def __str__(self):
+        return 'str'
+
+
+class _ObjWithRepr:
+    def __repr__(self):
+        return 'repr'
+
+
+_now = datetime.datetime.now()
+
+
+@pytest.mark.parametrize(
+    ('obj', 'expected'),
+    [
+        (_ObjWithStr(), 'str'),
+        (_ObjWithRepr(), 'repr'),
+        (_now, _now.isoformat()),
+        (_now.time(), _now.time().isoformat()),
+        (_now.date(), _now.date().isoformat()),
+    ]
+)
+def test_object_to_json(obj, expected):
+    result = gelf.object_to_json(obj)
+    assert result == expected
 
 
 @pytest.mark.parametrize('compress', [True, False])
 def test_pack(compress):
-    message = {'version': '1.1', 'short_message': 'test pack'}
-    packed_message = gelf.pack(message, compress)
+    message = {'version': '1.1', 'short_message': 'test pack', 'foo': _ObjWithStr()}
+    expected = json.loads(json.dumps(message, default=str))
+    packed_message = gelf.pack(message, compress, default=str)
     unpacked_message = zlib.decompress(packed_message) if compress else packed_message
     unpacked_message = json.loads(unpacked_message.decode('utf-8'))
-    assert message == unpacked_message
+    assert expected == unpacked_message
 
 
 def test_split():


### PR DESCRIPTION
Sometimes log record includes additional fields that I want to see in graylog but such fields values are objects that cannot be serialized to json by default.
This PR is my approach to deal with this. It adds additional function that serializes all such object and sets it as default value for `default` argument of `json.dumps()` function.
Additionally it sets `separators` argument of `json.dumps()` function to make a little bit more compact json representation.