### PR TITLE
Added syslog int handling to make() function in gelf.py

### DIFF
--- a/pygelf/gelf.py
+++ b/pygelf/gelf.py
@@ -34,7 +34,7 @@ def make(record, domain, debug, version, additional_fields, include_extra_fields
         'version': version,
         'short_message': record.getMessage(),
         'timestamp': record.created,
-        'level': LEVELS[record.levelno],
+        'level': LEVELS[record.levelno] if type(record.levelno) != int else record.levelno,
         'host': domain
     }
 


### PR DESCRIPTION

I noticed that if the `logging.basicConfig()` is constructed with an object it translates to a number before it reaches the `make()` function. 

This causes a key error in the `Levels` dict. 

I added some functionality to ignore this mapping if it already receives an int type. 

Might be more handling that should be done here but seems like it doesn't worsen the error handling. 

## Steps to reproduce

Initialize logging.BasicConfig with an `int` then with a level object `logging.DEBUG`