### PR TITLE
Added support for `additional_env_fields` argument in kwargs

### DIFF
--- a/pygelf/gelf.py
+++ b/pygelf/gelf.py
@@ -29,7 +29,7 @@ SKIP_LIST = (
 )
 
 
-def make(record, domain, debug, version, additional_fields, include_extra_fields=False):
+def make(record, domain, debug, version, additional_fields, additional_env_fields, include_extra_fields=False):
     gelf = {
         'version': version,
         'short_message': record.getMessage(),
@@ -54,6 +54,14 @@ def make(record, domain, debug, version, additional_fields, include_extra_fields
 
     if additional_fields is not None:
         gelf.update(additional_fields)
+
+    if additional_env_fields is not None:
+        appended = {}
+        for name, env in additional_env_fields:
+            if env in os.environ:
+                appended["_" + name] = os.environ.get(env)
+
+        gelf.update(appended)
 
     if include_extra_fields:
         add_extra_fields(gelf, record)

--- a/pygelf/handlers.py
+++ b/pygelf/handlers.py
@@ -13,7 +13,7 @@ from pygelf import gelf
 
 class BaseHandler(object):
     def __init__(self, debug=False, version='1.1', include_extra_fields=False, compress=False,
-                 static_fields=None, json_default=gelf.object_to_json, **kwargs):
+                 static_fields=None, json_default=gelf.object_to_json, additional_env_fields=None, **kwargs):
         """
         Logging handler that transforms each record into GELF (graylog extended log format) and sends it over TCP.
 
@@ -23,6 +23,10 @@ class BaseHandler(object):
         :param kwargs: additional fields that will be included in the log message, e.g. application name.
                        Each additional field should start with underscore, e.g. _app_name
         """
+
+        self.additional_env_fields = additional_env_fields
+        if self.additional_env_fields is None:
+            self.additional_env_fields = {}
 
         self.debug = debug
         self.version = version
@@ -35,7 +39,7 @@ class BaseHandler(object):
 
     def convert_record_to_gelf(self, record):
         return gelf.pack(
-            gelf.make(record, self.domain, self.debug, self.version, self.additional_fields, self.include_extra_fields),
+            gelf.make(record, self.domain, self.debug, self.version, self.additional_fields, self.additional_env_fields, self.include_extra_fields),
             self.compress, self.json_default
         )
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     keywords='logging udp tcp ssl tls graylog2 graylog gelf',
     author='Ivan Mukhin',
     author_email='muhin.ivan@gmail.com',
-    url='https://github.com/keeprocking/pygelf',
+    url='https://github.com/kepeder/pygelf',
     long_description=open('README.rst').read(),
     license='MIT',
     classifiers=[


### PR DESCRIPTION
Added support for sending `additional_env_fields` as kwargs.

In Python logger (INIs), it can be used as follows:
```
[handler_graylog]
class=pygelf.GelfTcpHandler
formatter=standard
args=('GELF_HOST', 'GELF_PORT')
kwargs={'include_extra_fields': True, 'debug': True, 'static_fields': {'name': 'api'}, 'additional_env_fields': {'env': 'FLASK_ENV'}}
```